### PR TITLE
fix(user.removeWebpush):

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -466,7 +466,7 @@ export default class User {
     }
 
     const deviceId: string = this.getDeviceId();
-
+    
     return this.appendInternal({
       $webpush: push,
       $id_provider: 'vapid',
@@ -485,7 +485,9 @@ export default class User {
     }
 
     const deviceId: string = this.getDeviceId();
-
+    
+    await push.unsubscribe();
+    
     return this.removeInternal({
       $webpush: push,
       $id_provider: 'vapid',


### PR DESCRIPTION
Currently, in `user.removeWebpush()` method of `user `API, the SuprSend SDK does not unsubscribe from push service in user's browser locally. 
This results in methods like `pushSubscribed()` returning incorrect status, as old subscriptions are not properly cleaned up. 

This change adds the missing unsubscribe logic to the SDK, ensuring accurate state and data integrity between suprsend backend and user's browser.